### PR TITLE
17_AWSテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,11 +15,15 @@ gem 'devise'
 # 多言語対応化gemを追加
 gem 'devise-i18n'
 gem 'rails-i18n', '~> 6.0'
+# Markdown用のgemを追加
+gem 'redcarpet'
+# シンタックスハイライト
+gem 'coderay'
 
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  
+
   # デバック用のgemを追加
   gem 'pry-byebug'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -210,6 +211,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-i18n
   jbuilder (~> 2.7)
@@ -221,6 +223,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n (~> 6.0)
+  redcarpet
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -2,4 +2,8 @@ class AwsTextsController < ApplicationController
   def index
     @aws_texts = AwsText.all
   end
+
+  def show
+    @aws_text = AwsText.find(params[:id])
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,48 @@
 module ApplicationHelper
+  require "redcarpet"
+  require "coderay"
+
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+    def block_code(code, language)
+      language = language.split(":")[0] if language.present?
+
+      case language.to_s
+      when "rb"
+        lang = :ruby
+      when "yml"
+        lang = :yaml
+      when "css"
+        lang = :css
+      when "html"
+        lang = :html
+      when ""
+        lang = :md
+      else
+        lang = language
+      end
+
+      CodeRay.scan(code, lang).div
+    end
+  end
+
+  def markdown(text)
+    html_render = HTMLwithCoderay.new(
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { rel: "nofollow", target: "_blank" },
+    )
+    options = {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true,
+    }
+    markdown = Redcarpet::Markdown.new(html_render, options)
+    markdown.render(text).html_safe
+  end
 end

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -15,7 +15,7 @@
         <% @aws_texts.each.with_index(1) do |aws_text, index| %>
           <tr>
             <th><%= index %></th>
-            <td><a href="" target="_blank"><%= aws_text.title %></a></td>
+            <td><%= link_to aws_text.title, aws_text_path(aws_text.id), target: :_blank %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,0 +1,2 @@
+<%= markdown(@aws_text.title) %>
+<%= markdown(@aws_text.content) %>


### PR DESCRIPTION
## 実装内容

- link_toメソッドを使用し、一覧ページの「内容」から詳細ページに移動できるように修正
- 詳細ページの作成およびMarkdownに対応した表示

## 参考資料

- Markdownの導入
  - [やんばるCODEアプリ](https://arcane-gorge-21903.herokuapp.com/texts/224)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認


