### PR TITLE
rakeコマンドの追加、修正

### DIFF
--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,4 +1,4 @@
 class Movie < ApplicationRecord
-  validates :title, presence: true, length: { maximum: 100 }
+  validates :title, presence: true, length: { maximum: 101 }
   validates :url, presence: true
 end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -3,10 +3,10 @@ require 'import.rb'
 
 namespace :import_csv do
   
-#aws_tect_date
-  desc "aws_text_data.csvをインポートするタスク"  
+  #aws_tect_date
+  desc "aws_text_data.csvをインポートするタスク"
   task aws_text: :environment do
-    
+
     puts "インポート処理を開始！"
     list = Import.csv_data(path: "db/csv_data/aws_text_data.csv")
     AwsText.delete_all
@@ -27,10 +27,10 @@ namespace :import_csv do
 
 
 
-#movie_data
+  #movie_data
   desc "movie_data.csvをインポートするタスク"
   task movie: :environment do
-    
+
     puts "インポート処理を開始！"
     Movie.delete_all
     list = Import.csv_data(path: "db/csv_data/movie_data.csv")
@@ -51,6 +51,27 @@ namespace :import_csv do
 
 
 
-  #line_date
-  
+  #line_data
+  desc "line_data.csvをインポートするタスク"
+  task line: :environment do
+
+    puts "インポート処理を開始！"
+    Line.delete_all
+    list = Import.csv_data(path: "db/csv_data/line_data.csv")
+
+    # インポートできなかった場合
+    begin
+      Movie.create!(list)
+      puts "インポート完了！"
+    rescue => e
+      #例外が発生した時の処理
+      puts "#{e.class}: #{e.message}"
+      puts "-------------------------"
+      puts e.backtrace # 例外が発生した位置情報
+      puts "-------------------------"
+      puts "インポートに失敗"
+    end
+  end
+
+
 end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -74,4 +74,28 @@ namespace :import_csv do
   end
 
 
+
+  #text_data
+  desc "line_data.csvをインポートするタスク"
+  task text: :environment do
+
+    puts "インポート処理を開始！"
+    Text.delete_all
+    list = Import.csv_data(path: "db/csv_data/text_data.csv")
+
+    # インポートできなかった場合
+    begin
+      Movie.create!(list)
+      puts "インポート完了！"
+    rescue => e
+      #例外が発生した時の処理
+      puts "#{e.class}: #{e.message}"
+      puts "-------------------------"
+      puts e.backtrace # 例外が発生した位置情報
+      puts "-------------------------"
+      puts "インポートに失敗"
+    end
+  end
+
+
 end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -76,7 +76,7 @@ namespace :import_csv do
 
 
   #text_data
-  desc "line_data.csvをインポートするタスク"
+  desc "text_data.csvをインポートするタスク"
   task text: :environment do
 
     puts "インポート処理を開始！"
@@ -97,5 +97,27 @@ namespace :import_csv do
     end
   end
 
+
+  #question_data
+  desc "question.csvをインポートするタスク"
+  task question: :environment do
+
+    puts "インポート処理を開始！"
+    Question.delete_all
+    list = Import.csv_data(path: "db/csv_data/question_data.csv")
+
+    # インポートできなかった場合
+    begin
+      Movie.create!(list)
+      puts "インポート完了！"
+    rescue => e
+      #例外が発生した時の処理
+      puts "#{e.class}: #{e.message}"
+      puts "-------------------------"
+      puts e.backtrace # 例外が発生した位置情報
+      puts "-------------------------"
+      puts "インポートに失敗"
+    end
+  end 
 
 end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -2,13 +2,14 @@
 require 'import.rb'
 
 namespace :import_csv do
-  desc "aws_text_data.csvをインポートするタスク"
   
+#aws_tect_date
+  desc "aws_text_data.csvをインポートするタスク"  
   task aws_text: :environment do
-    # import.rbのデータを取得
-    list = Import.csv_data(path: "db/csv_data/aws_text_data.csv")
-
+    
     puts "インポート処理を開始！"
+    list = Import.csv_data(path: "db/csv_data/aws_text_data.csv")
+    AwsText.delete_all
 
     # インポートできなかった場合
     begin
@@ -25,12 +26,14 @@ namespace :import_csv do
   end
 
 
+
+#movie_data
   desc "movie_data.csvをインポートするタスク"
   task movie: :environment do
-    # import.rbのデータを取得
-    list = Import.csv_data(path: "db/csv_data/movie_data.csv")
-
+    
     puts "インポート処理を開始！"
+    Movie.delete_all
+    list = Import.csv_data(path: "db/csv_data/movie_data.csv")
 
     # インポートできなかった場合
     begin
@@ -45,4 +48,9 @@ namespace :import_csv do
       puts "インポートに失敗"
     end
   end
+
+
+
+  #line_date
+  
 end


### PR DESCRIPTION
## 実装内容
- Movieのrakeタスク時に、既存のデータを全て消す処理を追加
- rake import_csv:lineを作成
- line_data.csvをインポートするタスク
- rake import_csv:questioを追加

## チェックリスト
- [ ] - Movie.delete_allを追加して、rails db:migrate:resetを実行する手間を省く
- [ ] 新しく追加したcsvファイルをimportできるようにrakeタスクを追加する(line_data,text_date,question_date)
- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認


## 備考
- 今回はrakeタスクのみ
- テーブルの作成は別タスクとしてみています。